### PR TITLE
Set style for email input and background-color for inputs

### DIFF
--- a/app/main/static/main/css/style.css
+++ b/app/main/static/main/css/style.css
@@ -145,6 +145,7 @@ input[type="text"], input[type="password"], input[type="email"] {
     width: 17em;
     padding: .3em .5em;
     box-shadow: 0 4px 1em rgba(0, 0, 0, 0.08) inset;
+    background-color: #FFF;
 }
 
 input[type="submit"] {

--- a/app/main/static/main/css/style.css
+++ b/app/main/static/main/css/style.css
@@ -137,7 +137,7 @@ form table th {
     padding-right: .5em;
 }
 
-input[type="text"], input[type="password"] {
+input[type="text"], input[type="password"], input[type="email"] {
     color: #444;
     border: solid 1px rgba(82, 168, 236, 0.8);
     border-radius: 4px;


### PR DESCRIPTION
Two things: 
 * First use the same style for the email input as for the text and password inputs on the `edit/` page.
 * Second, the text color of inputs is dark (`#444`), so I setup a light color (white) for the inputs backgrounds. 

As I use the dark GTK3 theme, and that now firefox use GTK3, by default, the background of my inputs is dark and the text color is light. Just set the text color in the css make for me impossible to read it (dark color on dark background).